### PR TITLE
Fix: モードを切り替えると必要なデータがローカルストレージから消える

### DIFF
--- a/packages/frontend/src/components/HanaHanaModeSwitcher.vue
+++ b/packages/frontend/src/components/HanaHanaModeSwitcher.vue
@@ -43,7 +43,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue';
-import { signinRequired, updateAccount } from '@/account.js';
+import { signinRequired, updateAccountPartial } from '@/account.js';
 import { i18n } from '@/i18n.js';
 import { globalEvents } from '@/events.js';
 import { claimAchievement } from '@/scripts/achievements.js';
@@ -92,7 +92,7 @@ async function setMode() {
 		os.apiWithDialog('i/update', {
 			isInHanaMode,
 		});
-		updateAccount({ isInHanaMode });
+		updateAccountPartial({ isInHanaMode });
 	}
 	emit('set');
 	onceSet.value = true;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
updateAccountで実装されていたモード変更時の更新処理をupdateAccountPartialに変更した。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

updateAccountだと
```
export function updateAccount(accountData: Account) {
	if (!$i) return;
	for (const key of Object.keys($i)) {
		delete $i[key];
	}
	for (const [key, value] of Object.entries(accountData)) {
		$i[key] = value;
	}
	miLocalStorage.setItem('account', JSON.stringify($i));
}
```
となっているため、指定したアカウントデータ以外の情報が消えてしまう。
そのため、updateAccountPartialに該当部分を置き換える。
updateAccountPartialは該当のKVだけを更新するため、他の情報が消えない。
```
export function updateAccountPartial(accountData: Partial<Account>) {
	if (!$i) return;
	for (const [key, value] of Object.entries(accountData)) {
		$i[key] = value;
	}
	miLocalStorage.setItem('account', JSON.stringify($i));
}
```
## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
updateAccountは実質的にreplaceAccountなので名前と動作が若干合ってない感じがする

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
