### PR TITLE
chore: Meilisearchへの接続を使ってヘルスチェックをしないように

### DIFF
--- a/packages/backend/src/server/HealthServerService.ts
+++ b/packages/backend/src/server/HealthServerService.ts
@@ -10,7 +10,6 @@ import { bindThis } from '@/decorators.js';
 import { DI } from '@/di-symbols.js';
 import { readyRef } from '@/boot/ready.js';
 import type { FastifyInstance, FastifyPluginOptions } from 'fastify';
-import type { MeiliSearch } from 'meilisearch';
 
 @Injectable()
 export class HealthServerService {
@@ -33,8 +32,6 @@ export class HealthServerService {
 		@Inject(DI.db)
 		private db: DataSource,
 
-		@Inject(DI.meilisearch)
-		private meilisearch: MeiliSearch | null,
 	) {}
 
 	@bindThis
@@ -48,7 +45,6 @@ export class HealthServerService {
 				this.redisForTimelines.ping(),
 				this.redisForReactions.ping(),
 				this.db.query('SELECT 1'),
-				...(this.meilisearch ? [this.meilisearch.health()] : []),
 			]).then(() => 200, () => 503));
 			reply.header('Cache-Control', 'no-store');
 		});


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
ヘルスチェックからMeilisearchの項目を削除した

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
1.  現状Meilisearchはクラスタ構成を正式サポートしておらず、クラスタ構成で運用を行っていない
2. そのため、単一障害点であり、障害を比較的引き起こしやすい状態にある
3. また、Meilisearchに接続できることは、他のRedisやPostgreSQLへの接続に対して重要性が低い
4. Meilisearchに接続できないことを理由に503を返すと、デグレした状態で動作可能にもかかわらずCrashLoopBackOffでMisskey自体が落ちる

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
- 暫定的な削除
- 本来は別のエンドポイントを作成して監視可能であるべき


## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
