### PR TITLE
enhance: ミュートした人のリアクションが一般的なAPIで表示されないように

### DIFF
--- a/packages/backend/src/core/FanoutTimelineEndpointService.ts
+++ b/packages/backend/src/core/FanoutTimelineEndpointService.ts
@@ -51,7 +51,7 @@ export class FanoutTimelineEndpointService {
 
 	@bindThis
 	async timeline(ps: TimelineOptions): Promise<Packed<'Note'>[]> {
-		const packedNotes = await this.noteEntityService.packMany(await this.getMiNotes(ps), ps.me, { withReactionAndUserPairCache: true });
+		const packedNotes = await this.noteEntityService.packMany(await this.getMiNotes(ps), ps.me, ps.me ? { withReactionAndUserPairCache: true } : undefined);
 		if (ps.me) {
 			const userIdsWhoMeMuting = await this.cacheService.userMutingsCache.fetch(ps.me.id);
 			await Promise.all(

--- a/packages/backend/src/core/FanoutTimelineEndpointService.ts
+++ b/packages/backend/src/core/FanoutTimelineEndpointService.ts
@@ -17,6 +17,7 @@ import { isQuote, isRenote } from '@/misc/is-renote.js';
 import { CacheService } from '@/core/CacheService.js';
 import { isReply } from '@/misc/is-reply.js';
 import { isInstanceMuted } from '@/misc/is-instance-muted.js';
+import { removeMutedUsersReactions } from '@/misc/reactions-mute.js';
 
 type TimelineOptions = {
 	untilId: string | null,
@@ -50,7 +51,14 @@ export class FanoutTimelineEndpointService {
 
 	@bindThis
 	async timeline(ps: TimelineOptions): Promise<Packed<'Note'>[]> {
-		return await this.noteEntityService.packMany(await this.getMiNotes(ps), ps.me);
+		const packedNotes = await this.noteEntityService.packMany(await this.getMiNotes(ps), ps.me, { withReactionAndUserPairCache: true });
+		if (ps.me) {
+			const userIdsWhoMeMuting = await this.cacheService.userMutingsCache.fetch(ps.me.id);
+			await Promise.all(
+				packedNotes.map(note => removeMutedUsersReactions(note, userIdsWhoMeMuting)),
+			);
+		}
+		return packedNotes;
 	}
 
 	@bindThis

--- a/packages/backend/src/core/SearchService.ts
+++ b/packages/backend/src/core/SearchService.ts
@@ -9,6 +9,7 @@ import { DI } from '@/di-symbols.js';
 import { type Config, FulltextSearchProvider } from '@/config.js';
 import { bindThis } from '@/decorators.js';
 import { MiNote } from '@/models/Note.js';
+import { Packed } from '@/misc/json-schema.js';
 import type { NotesRepository } from '@/models/_.js';
 import { MiUser } from '@/models/_.js';
 import { sqlLikeEscape } from '@/misc/sql-like-escape.js';
@@ -17,6 +18,9 @@ import { CacheService } from '@/core/CacheService.js';
 import { QueryService } from '@/core/QueryService.js';
 import { IdService } from '@/core/IdService.js';
 import { LoggerService } from '@/core/LoggerService.js';
+import { isMustRemove } from '@/misc/is-hidden-or-visibility-modified.js';
+import { removeMutedUsersReactions } from '@/misc/reactions-mute.js';
+import { NoteEntityService } from '@/core/entities/NoteEntityService.js';
 import type { Index, MeiliSearch } from 'meilisearch';
 
 type K = string;
@@ -90,6 +94,7 @@ export class SearchService {
 		@Inject(DI.notesRepository)
 		private notesRepository: NotesRepository,
 
+		private noteEntityService: NoteEntityService,
 		private cacheService: CacheService,
 		private queryService: QueryService,
 		private idService: IdService,
@@ -178,16 +183,24 @@ export class SearchService {
 		me: MiUser | null,
 		opts: SearchOpts,
 		pagination: SearchPagination,
-	): Promise<MiNote[]> {
+	): Promise<Packed<'Note'>[]> {
+		const [
+			userIdsWhoMeMuting,
+			userIdsWhoBlockingMe,
+		] = me ? await Promise.all([
+			this.cacheService.userMutingsCache.fetch(me.id),
+			this.cacheService.userBlockedCache.fetch(me.id),
+		]) : [new Set<string>(), new Set<string>()];
+
 		switch (this.provider) {
 			case 'sqlLike':
 			case 'sqlPgroonga': {
 				// ほとんど内容に差がないのでsqlLikeとsqlPgroongaを同じ処理にしている.
 				// 今後の拡張で差が出る用であれば関数を分ける.
-				return this.searchNoteByLike(q, me, opts, pagination);
+				return this.searchNoteByLike(q, me, opts, pagination, userIdsWhoMeMuting, userIdsWhoBlockingMe);
 			}
 			case 'meilisearch': {
-				return this.searchNoteByMeiliSearch(q, me, opts, pagination);
+				return this.searchNoteByMeiliSearch(q, me, opts, pagination, userIdsWhoMeMuting, userIdsWhoBlockingMe);
 			}
 			default: {
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -203,7 +216,9 @@ export class SearchService {
 		me: MiUser | null,
 		opts: SearchOpts,
 		pagination: SearchPagination,
-	): Promise<MiNote[]> {
+		userIdsWhoMeMuting: Set<string>,
+		userIdsWhoBlockingMe: Set<string>,
+	): Promise<Packed<'Note'>[]> {
 		const query = this.queryService.makePaginationQuery(this.notesRepository.createQueryBuilder('note'), pagination.sinceId, pagination.untilId);
 
 		if (opts.userId) {
@@ -234,10 +249,18 @@ export class SearchService {
 		}
 
 		this.queryService.generateVisibilityQuery(query, me);
-		if (me) this.queryService.generateMutedUserQuery(query, me);
-		if (me) this.queryService.generateBlockedUserQuery(query, me);
 
-		return query.limit(pagination.limit).getMany();
+		const notes = (await query.getMany()).filter(note => {
+			if (me && isUserRelated(note, userIdsWhoBlockingMe)) return false;
+			if (me && isUserRelated(note, userIdsWhoMeMuting)) return false;
+
+			return true;
+		});
+		const packedNotes = (await this.noteEntityService.packMany(notes, me, { withReactionAndUserPairCache: true })).filter(note => !isMustRemove(note, 'home'));
+		await Promise.all(
+			packedNotes.map(note => removeMutedUsersReactions(note, userIdsWhoMeMuting)),
+		);
+		return packedNotes;
 	}
 
 	@bindThis
@@ -246,7 +269,10 @@ export class SearchService {
 		me: MiUser | null,
 		opts: SearchOpts,
 		pagination: SearchPagination,
-	): Promise<MiNote[]> {
+		userIdsWhoMeMuting: Set<string>,
+		userIdsWhoBlockingMe: Set<string>,
+
+	): Promise<Packed<'Note'>[]> {
 		if (!this.meilisearch || !this.meilisearchNoteIndex) {
 			throw new Error('MeiliSearch is not available');
 		}
@@ -286,15 +312,6 @@ export class SearchService {
 			return [];
 		}
 
-		const [
-			userIdsWhoMeMuting,
-			userIdsWhoBlockingMe,
-		] = me
-			? await Promise.all([
-				this.cacheService.userMutingsCache.fetch(me.id),
-				this.cacheService.userBlockedCache.fetch(me.id),
-			])
-			: [new Set<string>(), new Set<string>()];
 		const notes = (await this.notesRepository.findBy({
 			id: In(res.hits.map(x => x.id)),
 		})).filter(note => {
@@ -303,6 +320,12 @@ export class SearchService {
 			return true;
 		});
 
-		return notes.sort((a, b) => a.id > b.id ? -1 : 1);
+		notes.sort((a, b) => a.id > b.id ? -1 : 1);
+		const packedNotes = (await this.noteEntityService.packMany(notes, me, { withReactionAndUserPairCache: true })).filter(note => !isMustRemove(note, 'home'));
+		await Promise.all(
+			packedNotes.map(note => removeMutedUsersReactions(note, userIdsWhoMeMuting)),
+		);
+
+		return packedNotes;
 	}
 }

--- a/packages/backend/src/core/entities/ChannelEntityService.ts
+++ b/packages/backend/src/core/entities/ChannelEntityService.ts
@@ -45,6 +45,7 @@ export class ChannelEntityService {
 		src: MiChannel['id'] | MiChannel,
 		me?: { id: MiUser['id'] } | null | undefined,
 		detailed?: boolean,
+		pinnedNotesWithReactionAndUserPairCache?: boolean | false,
 	): Promise<Packed<'Channel'>> {
 		const channel = typeof src === 'object' ? src : await this.channelsRepository.findOneByOrFail({ id: src });
 		const meId = me ? me.id : null;
@@ -94,7 +95,7 @@ export class ChannelEntityService {
 			} : {}),
 
 			...(detailed ? {
-				pinnedNotes: (await this.noteEntityService.packMany(pinnedNotes, me)).sort((a, b) => channel.pinnedNoteIds.indexOf(a.id) - channel.pinnedNoteIds.indexOf(b.id)),
+				pinnedNotes: (await this.noteEntityService.packMany(pinnedNotes, me, { withReactionAndUserPairCache: pinnedNotesWithReactionAndUserPairCache })).sort((a, b) => channel.pinnedNoteIds.indexOf(a.id) - channel.pinnedNoteIds.indexOf(b.id)),
 			} : {}),
 		};
 	}

--- a/packages/backend/src/core/entities/NoteEntityService.ts
+++ b/packages/backend/src/core/entities/NoteEntityService.ts
@@ -478,6 +478,7 @@ export class NoteEntityService implements OnModuleInit {
 		options?: {
 			detail?: boolean;
 			skipHide?: boolean;
+			withReactionAndUserPairCache?: boolean;
 		},
 	) {
 		if (notes.length === 0) return [];

--- a/packages/backend/src/core/entities/NoteFavoriteEntityService.ts
+++ b/packages/backend/src/core/entities/NoteFavoriteEntityService.ts
@@ -28,6 +28,7 @@ export class NoteFavoriteEntityService {
 	public async pack(
 		src: MiNoteFavorite['id'] | MiNoteFavorite,
 		me?: { id: MiUser['id'] } | null | undefined,
+		withReactionAndUserPairCache?: boolean,
 	) {
 		const favorite = typeof src === 'object' ? src : await this.noteFavoritesRepository.findOneByOrFail({ id: src });
 
@@ -35,7 +36,7 @@ export class NoteFavoriteEntityService {
 			id: favorite.id,
 			createdAt: this.idService.parse(favorite.id).date.toISOString(),
 			noteId: favorite.noteId,
-			note: await this.noteEntityService.pack(favorite.note ?? favorite.noteId, me),
+			note: await this.noteEntityService.pack(favorite.note ?? favorite.noteId, me, { withReactionAndUserPairCache: withReactionAndUserPairCache }),
 		};
 	}
 
@@ -43,7 +44,8 @@ export class NoteFavoriteEntityService {
 	public packMany(
 		favorites: any[],
 		me: { id: MiUser['id'] },
+		withReactionAndUserPairCache?: boolean,
 	) {
-		return Promise.all(favorites.map(x => this.pack(x, me)));
+		return Promise.all(favorites.map(x => this.pack(x, me, withReactionAndUserPairCache)));
 	}
 }

--- a/packages/backend/src/core/entities/UserEntityService.ts
+++ b/packages/backend/src/core/entities/UserEntityService.ts
@@ -403,6 +403,7 @@ export class UserEntityService implements OnModuleInit {
 			userRelations?: Map<MiUser['id'], UserRelation>,
 			userMemos?: Map<MiUser['id'], string | null>,
 			pinNotes?: Map<MiUser['id'], MiUserNotePining[]>,
+			pinNotesWithReactionAndUserPairCache?: boolean,
 		},
 	): Promise<Packed<S>> {
 		const opts = Object.assign({
@@ -543,6 +544,7 @@ export class UserEntityService implements OnModuleInit {
 				pinnedNoteIds: pins.map(pin => pin.noteId),
 				pinnedNotes: this.noteEntityService.packMany(pins.map(pin => pin.note!), me, {
 					detail: true,
+					withReactionAndUserPairCache: opts.pinNotesWithReactionAndUserPairCache,
 				}),
 				pinnedPageId: profile!.pinnedPageId,
 				pinnedPage: profile!.pinnedPageId ? this.pageEntityService.pack(profile!.pinnedPageId, me) : null,

--- a/packages/backend/src/core/hanamisearch/HanamiSearchService.ts
+++ b/packages/backend/src/core/hanamisearch/HanamiSearchService.ts
@@ -8,13 +8,16 @@ import { In } from 'typeorm';
 import { DI } from '@/di-symbols.js';
 import type { Config } from '@/config.js';
 import { bindThis } from '@/decorators.js';
+import { Packed } from '@/misc/json-schema.js';
 import { MiNote } from '@/models/Note.js';
 import { MiUser } from '@/models/_.js';
 import type { NotesRepository } from '@/models/_.js';
 import { isUserRelated } from '@/misc/is-user-related.js';
 import { CacheService } from '@/core/CacheService.js';
-import { QueryService } from '@/core/QueryService.js';
 import { IdService } from '@/core/IdService.js';
+import { isMustRemove } from '@/misc/is-hidden-or-visibility-modified.js';
+import { NoteEntityService } from '@/core/entities/NoteEntityService.js';
+import { removeMutedUsersReactions } from '@/misc/reactions-mute.js';
 import type { Index, MeiliSearch } from 'meilisearch';
 
 type K = string;
@@ -75,6 +78,7 @@ export class HanamiSearchService {
 		@Inject(DI.notesRepository)
 		private notesRepository: NotesRepository,
 
+		private noteEntityService: NoteEntityService,
 		private cacheService: CacheService,
 		private idService: IdService,
 	) {
@@ -177,7 +181,7 @@ export class HanamiSearchService {
 			sinceId?: MiNote['id'];
 			limit?: number;
 		},
-	): Promise<MiNote[]> {
+	): Promise<Packed<'Note'>[]> {
 		const preferredMethod = opts.preferredMethod ?? 'hanamisearchv1';
 
 		if ((preferredMethod === 'hanamisearchv1' && this.hanamisearch)) {
@@ -205,7 +209,7 @@ export class HanamiSearchService {
 			limit?: number;
 		},
 		shouldTimeSeriesSort: boolean,
-	): Promise<MiNote[]> {
+	): Promise<Packed<'Note'>[]> {
 		const filter: Q = { op: 'and', qs: [] };
 
 		if (pagination.untilId) filter.qs.push({ op: '<', k: 'createdAt', v: this.idService.parse(pagination.untilId).date.getTime() });
@@ -242,6 +246,12 @@ export class HanamiSearchService {
 			return true;
 		});
 
-		return shouldTimeSeriesSort ? notes.sort((a, b) => (a.id > b.id ? -1 : 1)) : notes;
+		notes.sort((a, b) => a.id > b.id ? -1 : 1);
+		const packedNotes = (await this.noteEntityService.packMany(notes, me, { withReactionAndUserPairCache: true })).filter(note => !isMustRemove(note, 'home'));
+		await Promise.all(
+			packedNotes.map(note => removeMutedUsersReactions(note, userIdsWhoMeMuting)),
+		);
+
+		return packedNotes;
 	}
 }

--- a/packages/backend/src/misc/reactions-mute.ts
+++ b/packages/backend/src/misc/reactions-mute.ts
@@ -1,0 +1,44 @@
+import { Packed } from '@/misc/json-schema.js';
+
+export async function removeMutedUsersReactions(note: Packed<'Note'>, userIdsWhoMeMuting: Set<string>): Promise<Packed<'Note'>> {
+	if (!note.reactions || !note.reactionAndUserPairCache) {
+		delete note.reactionAndUserPairCache;
+		return note;
+	}
+
+	const mutedReactionsCount = new Map<string, number>();
+
+	for (const entry of note.reactionAndUserPairCache) {
+		const [userId, reaction] = entry.split('/');
+		if (!reaction || !userId) {
+			continue;
+		}
+
+		// ミュートされたユーザーの場合のみ処理
+		if (userIdsWhoMeMuting.has(userId)) {
+			mutedReactionsCount.set(
+				reaction,
+				(mutedReactionsCount.get(reaction) || 0) + 1,
+			);
+		}
+	}
+
+	for (const reactionKey of Object.keys(note.reactions)) {
+		const isLocalEmoji = reactionKey.endsWith('@.:');
+		const normalizedKey = isLocalEmoji ? reactionKey.replace('@.', '') : reactionKey;
+		const mutedCount = mutedReactionsCount.get(normalizedKey) || 0;
+
+		// ミュートされたリアクションが存在する場合のみ処理
+		if (mutedCount > 0) {
+			note.reactions[reactionKey] -= mutedCount;
+			note.reactionCount -= mutedCount;
+
+			// リアクション数がゼロ以下になった場合は削除
+			if (note.reactions[reactionKey] <= 0) {
+				delete note.reactions[reactionKey];
+			}
+		}
+	}
+	delete note.reactionAndUserPairCache;
+	return note;
+}

--- a/packages/backend/src/server/api/endpoints/antennas/notes.ts
+++ b/packages/backend/src/server/api/endpoints/antennas/notes.ts
@@ -16,6 +16,9 @@ import { FanoutTimelineService } from '@/core/FanoutTimelineService.js';
 import { GlobalEventService } from '@/core/GlobalEventService.js';
 import { trackPromise } from '@/misc/promise-tracker.js';
 import { isMustRemove } from '@/misc/is-hidden-or-visibility-modified.js';
+import { isUserRelated } from '@/misc/is-user-related.js';
+import { CacheService } from '@/core/CacheService.js';
+import { removeMutedUsersReactions } from '@/misc/reactions-mute.js';
 import { ApiError } from '../../error.js';
 
 export const meta = {
@@ -69,6 +72,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		@Inject(DI.antennasRepository)
 		private antennasRepository: AntennasRepository,
 
+		private cacheService: CacheService,
 		private idService: IdService,
 		private noteEntityService: NoteEntityService,
 		private queryService: QueryService,
@@ -106,6 +110,14 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				return [];
 			}
 
+			const [
+				userIdsWhoMeMuting,
+				userIdsWhoBlockingMe,
+			] = me ? await Promise.all([
+				this.cacheService.userMutingsCache.fetch(me.id),
+				this.cacheService.userBlockedCache.fetch(me.id),
+			]) : [new Set<string>(), new Set<string>()];
+
 			const query = this.notesRepository.createQueryBuilder('note')
 				.where('note.id IN (:...noteIds)', { noteIds: noteIds })
 				.innerJoinAndSelect('note.user', 'user')
@@ -115,10 +127,14 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				.leftJoinAndSelect('renote.user', 'renoteUser');
 
 			this.queryService.generateVisibilityQuery(query, me);
-			this.queryService.generateMutedUserQuery(query, me);
-			this.queryService.generateBlockedUserQuery(query, me);
 
-			const notes = await query.getMany();
+			const notes = (await query.getMany()).filter(note => {
+				if (isUserRelated(note, userIdsWhoBlockingMe)) return false;
+				if (isUserRelated(note, userIdsWhoMeMuting)) return false;
+
+				return true;
+			});
+
 			if (sinceId != null && untilId == null) {
 				notes.sort((a, b) => a.id < b.id ? -1 : 1);
 			} else {
@@ -127,7 +143,11 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 
 			this.noteReadService.read(me.id, notes);
 
-			return (await this.noteEntityService.packMany(notes, me)).filter(note => !isMustRemove(note, 'home'));
+			const packedNotes = (await this.noteEntityService.packMany(notes, me, { withReactionAndUserPairCache: true })).filter(note => !isMustRemove(note, 'home'));
+			await Promise.all(
+				packedNotes.map(note => removeMutedUsersReactions(note, userIdsWhoMeMuting)),
+			);
+			return packedNotes;
 		});
 	}
 }

--- a/packages/backend/src/server/api/endpoints/channels/show.ts
+++ b/packages/backend/src/server/api/endpoints/channels/show.ts
@@ -6,8 +6,11 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Endpoint } from '@/server/api/endpoint-base.js';
 import type { ChannelsRepository } from '@/models/_.js';
+import { CacheService } from '@/core/CacheService.js';
 import { ChannelEntityService } from '@/core/entities/ChannelEntityService.js';
+import { isUserRelated } from '@/misc/is-user-related.js';
 import { DI } from '@/di-symbols.js';
+import { removeMutedUsersReactions } from '@/misc/reactions-mute.js';
 import { ApiError } from '../../error.js';
 
 export const meta = {
@@ -44,6 +47,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		@Inject(DI.channelsRepository)
 		private channelsRepository: ChannelsRepository,
 
+		private cacheService: CacheService,
 		private channelEntityService: ChannelEntityService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
@@ -55,7 +59,25 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				throw new ApiError(meta.errors.noSuchChannel);
 			}
 
-			return await this.channelEntityService.pack(channel, me, true);
+			const packedChannel = await this.channelEntityService.pack(channel, me, true, true);
+			if (packedChannel.pinnedNotes) {
+				const [
+					userIdsWhoMeMuting,
+					userIdsWhoBlockingMe,
+				] = me ? await Promise.all([
+					this.cacheService.userMutingsCache.fetch(me.id),
+					this.cacheService.userBlockedCache.fetch(me.id),
+				]) : [new Set<string>(), new Set<string>()];
+				packedChannel.pinnedNotes.filter(note => {
+					if (me && isUserRelated(note, userIdsWhoBlockingMe)) return false;
+					if (me && isUserRelated(note, userIdsWhoMeMuting)) return false;
+					return true;
+				});
+				await Promise.all(
+					packedChannel.pinnedNotes.map(note => removeMutedUsersReactions(note, userIdsWhoMeMuting)),
+				);
+			}
+			return packedChannel;
 		});
 	}
 }

--- a/packages/backend/src/server/api/endpoints/clips/notes.ts
+++ b/packages/backend/src/server/api/endpoints/clips/notes.ts
@@ -9,6 +9,10 @@ import type { NotesRepository, ClipsRepository, ClipNotesRepository } from '@/mo
 import { QueryService } from '@/core/QueryService.js';
 import { NoteEntityService } from '@/core/entities/NoteEntityService.js';
 import { DI } from '@/di-symbols.js';
+import { removeMutedUsersReactions } from '@/misc/reactions-mute.js';
+import { CacheService } from '@/core/CacheService.js';
+import { isInstanceMuted } from '@/misc/is-instance-muted.js';
+import { isUserRelated } from '@/misc/is-user-related.js';
 import { ApiError } from '../../error.js';
 
 export const meta = {
@@ -60,6 +64,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		@Inject(DI.clipNotesRepository)
 		private clipNotesRepository: ClipNotesRepository,
 
+		private cacheService: CacheService,
 		private noteEntityService: NoteEntityService,
 		private queryService: QueryService,
 	) {
@@ -76,6 +81,16 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				throw new ApiError(meta.errors.noSuchClip);
 			}
 
+			const [
+				userIdsWhoMeMuting,
+				userIdsWhoBlockingMe,
+				userMutedInstances,
+			] = me ? await Promise.all([
+				this.cacheService.userMutingsCache.fetch(me.id),
+				this.cacheService.userBlockedCache.fetch(me.id),
+				this.cacheService.userProfileCache.fetch(me.id).then(p => new Set(p.mutedInstances)),
+			]) : [new Set<string>(), new Set<string>(), new Set<string>()];
+
 			const query = this.queryService.makePaginationQuery(this.notesRepository.createQueryBuilder('note'), ps.sinceId, ps.untilId)
 				.innerJoin(this.clipNotesRepository.metadata.targetName, 'clipNote', 'clipNote.noteId = note.id')
 				.innerJoinAndSelect('note.user', 'user')
@@ -87,15 +102,21 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 
 			if (me) {
 				this.queryService.generateVisibilityQuery(query, me);
-				this.queryService.generateMutedUserQuery(query, me);
-				this.queryService.generateBlockedUserQuery(query, me);
 			}
 
-			const notes = await query
-				.limit(ps.limit)
-				.getMany();
+			const notes = (await query.getMany()).filter(note => {
+				if (me && isUserRelated(note, userIdsWhoBlockingMe)) return false;
+				if (me && isUserRelated(note, userIdsWhoMeMuting)) return false;
+				if (me && isInstanceMuted(note, userMutedInstances)) return false;
 
-			return await this.noteEntityService.packMany(notes, me);
+				return true;
+			});
+
+			const packedNotes = await this.noteEntityService.packMany(notes, me, { withReactionAndUserPairCache: true });
+			await Promise.all(
+				packedNotes.map(note => removeMutedUsersReactions(note, userIdsWhoMeMuting)),
+			);
+			return packedNotes;
 		});
 	}
 }

--- a/packages/backend/src/server/api/endpoints/i.ts
+++ b/packages/backend/src/server/api/endpoints/i.ts
@@ -6,15 +6,17 @@
 import { Inject, Injectable } from '@nestjs/common';
 import type { UserProfilesRepository } from '@/models/_.js';
 import { Endpoint } from '@/server/api/endpoint-base.js';
+import { CacheService } from '@/core/CacheService.js';
 import { UserEntityService } from '@/core/entities/UserEntityService.js';
 import { DI } from '@/di-symbols.js';
+import { removeMutedUsersReactions } from '@/misc/reactions-mute.js';
 import { ApiError } from '../error.js';
 
 export const meta = {
 	tags: ['account'],
 
 	requireCredential: true,
-	kind: "read:account",
+	kind: 'read:account',
 
 	res: {
 		type: 'object',
@@ -44,6 +46,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		@Inject(DI.userProfilesRepository)
 		private userProfilesRepository: UserProfilesRepository,
 
+		private cacheService: CacheService,
 		private userEntityService: UserEntityService,
 	) {
 		super(meta, paramDef, async (ps, user, token) => {
@@ -71,11 +74,19 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				userProfile.loggedInDates = [...userProfile.loggedInDates, today];
 			}
 
-			return await this.userEntityService.pack(userProfile.user!, userProfile.user!, {
+			const packedUserProfile = await this.userEntityService.pack(userProfile.user!, userProfile.user!, {
 				schema: 'MeDetailed',
 				includeSecrets: isSecure,
 				userProfile,
+				pinNotesWithReactionAndUserPairCache: true,
 			});
+			if (packedUserProfile.pinnedNotes.length > 0) {
+				const userIdsWhoMeMuting = await this.cacheService.userMutingsCache.fetch(user.id);
+				await Promise.all(
+					packedUserProfile.pinnedNotes.map(note => removeMutedUsersReactions(note, userIdsWhoMeMuting)),
+				);
+			}
+			return packedUserProfile;
 		});
 	}
 }

--- a/packages/backend/src/server/api/endpoints/i/favorites.ts
+++ b/packages/backend/src/server/api/endpoints/i/favorites.ts
@@ -9,6 +9,8 @@ import type { NoteFavoritesRepository } from '@/models/_.js';
 import { QueryService } from '@/core/QueryService.js';
 import { NoteFavoriteEntityService } from '@/core/entities/NoteFavoriteEntityService.js';
 import { DI } from '@/di-symbols.js';
+import { removeMutedUsersReactions } from '@/misc/reactions-mute.js';
+import { CacheService } from '@/core/CacheService.js';
 
 export const meta = {
 	tags: ['account', 'notes', 'favorites'],
@@ -44,6 +46,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		@Inject(DI.noteFavoritesRepository)
 		private noteFavoritesRepository: NoteFavoritesRepository,
 
+		private cacheService: CacheService,
 		private noteFavoriteEntityService: NoteFavoriteEntityService,
 		private queryService: QueryService,
 	) {
@@ -56,7 +59,16 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				.limit(ps.limit)
 				.getMany();
 
-			return await this.noteFavoriteEntityService.packMany(favorites, me);
+			const packedFavorites = await this.noteFavoriteEntityService.packMany(favorites, me, true);
+			const userIdsWhoMeMuting = await this.cacheService.userMutingsCache.fetch(me.id);
+
+			return await Promise.all(packedFavorites.map(async fav => {
+				const note = fav.note;
+				return {
+					...fav,
+					note: await removeMutedUsersReactions(note, userIdsWhoMeMuting),
+				};
+			}));
 		});
 	}
 }

--- a/packages/backend/src/server/api/endpoints/notes/featured.ts
+++ b/packages/backend/src/server/api/endpoints/notes/featured.ts
@@ -11,6 +11,7 @@ import { DI } from '@/di-symbols.js';
 import { FeaturedService } from '@/core/FeaturedService.js';
 import { isUserRelated } from '@/misc/is-user-related.js';
 import { CacheService } from '@/core/CacheService.js';
+import { removeMutedUsersReactions } from '@/misc/reactions-mute.js';
 
 export const meta = {
 	tags: ['notes'],
@@ -106,7 +107,11 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 
 			notes.sort((a, b) => a.id > b.id ? -1 : 1);
 
-			return await this.noteEntityService.packMany(notes, me);
+			const packedNotes = await this.noteEntityService.packMany(notes, me, { withReactionAndUserPairCache: true });
+			await Promise.all(
+				packedNotes.map(note => removeMutedUsersReactions(note, userIdsWhoMeMuting)),
+			);
+			return packedNotes;
 		});
 	}
 }

--- a/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
@@ -8,10 +8,14 @@ import { Brackets } from 'typeorm';
 import type { NotesRepository } from '@/models/_.js';
 import { Endpoint } from '@/server/api/endpoint-base.js';
 import { QueryService } from '@/core/QueryService.js';
+import { CacheService } from '@/core/CacheService.js';
+import { isUserRelated } from '@/misc/is-user-related.js';
+import { isInstanceMuted } from '@/misc/is-instance-muted.js';
 import { NoteEntityService } from '@/core/entities/NoteEntityService.js';
 import ActiveUsersChart from '@/core/chart/charts/active-users.js';
 import { DI } from '@/di-symbols.js';
 import { RoleService } from '@/core/RoleService.js';
+import { removeMutedUsersReactions } from '@/misc/reactions-mute.js';
 import { ApiError } from '../../error.js';
 
 export const meta = {
@@ -57,6 +61,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		private notesRepository: NotesRepository,
 
 		private noteEntityService: NoteEntityService,
+		private cacheService: CacheService,
 		private queryService: QueryService,
 		private roleService: RoleService,
 		private activeUsersChart: ActiveUsersChart,
@@ -66,6 +71,16 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 			if (!policies.gtlAvailable) {
 				throw new ApiError(meta.errors.gtlDisabled);
 			}
+
+			const [
+				userIdsWhoMeMuting,
+				userIdsWhoBlockingMe,
+				userMutedInstances,
+			] = me ? await Promise.all([
+				this.cacheService.userMutingsCache.fetch(me.id),
+				this.cacheService.userBlockedCache.fetch(me.id),
+				this.cacheService.userProfileCache.fetch(me.id).then(p => new Set(p.mutedInstances)),
+			]) : [new Set<string>(), new Set<string>(), new Set<string>()];
 
 			//#region Construct query
 			const query = this.queryService.makePaginationQuery(this.notesRepository.createQueryBuilder('note'),
@@ -79,8 +94,6 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				.leftJoinAndSelect('renote.user', 'renoteUser');
 
 			if (me) {
-				this.queryService.generateMutedUserQuery(query, me);
-				this.queryService.generateBlockedUserQuery(query, me);
 				this.queryService.generateMutedUserRenotesQueryForNotes(query, me);
 			}
 
@@ -97,9 +110,15 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 					}));
 				}));
 			}
-			//#endregion
 
-			const timeline = await query.limit(ps.limit).getMany();
+			const notes = (await query.getMany()).filter(note => {
+				if (me && isUserRelated(note, userIdsWhoBlockingMe)) return false;
+				if (me && isUserRelated(note, userIdsWhoMeMuting)) return false;
+				if (me && isInstanceMuted(note, userMutedInstances)) return false;
+
+				return true;
+			});
+			//#endregion
 
 			process.nextTick(() => {
 				if (me) {
@@ -107,7 +126,11 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				}
 			});
 
-			return await this.noteEntityService.packMany(timeline, me);
+			const packedNotes = await this.noteEntityService.packMany(notes, me, { withReactionAndUserPairCache: true });
+			await Promise.all(
+				packedNotes.map(note => removeMutedUsersReactions(note, userIdsWhoMeMuting)),
+			);
+			return packedNotes;
 		});
 	}
 }

--- a/packages/backend/src/server/api/endpoints/notes/hanami-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/hanami-timeline.ts
@@ -26,6 +26,7 @@ import { FanoutTimelineEndpointService } from '@/core/FanoutTimelineEndpointServ
 import { FeaturedService } from '@/core/FeaturedService.js';
 import { isUserRelated } from '@/misc/is-user-related.js';
 import { isInstanceMuted } from '@/misc/is-instance-muted.js';
+import { removeMutedUsersReactions } from '@/misc/reactions-mute.js';
 import { ApiError } from '../../error.js';
 
 export const meta = {
@@ -115,7 +116,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 			}
 
 			const followingsPromise = this.cacheService.userFollowingsCache.fetch(me.id);
-			const [packedHomeTimelineNotes, feauturedNotes] = await Promise.all([
+			const [packedHomeTimelineNotes, packedFeauturedNotes] = await Promise.all([
 				(async () => {
 					const followings = await followingsPromise;
 					return this.fanoutTimelineEndpointService.timeline({
@@ -153,10 +154,9 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				}, me),
 			]);
 
-			if (feauturedNotes.length === 0) {
+			if (packedFeauturedNotes.length === 0) {
 				return packedHomeTimelineNotes;
 			}
-			const packedFeauturedNotes = await this.noteEntityService.packMany(feauturedNotes, me);
 
 			if (packedHomeTimelineNotes.length === 0) {
 				return packedFeauturedNotes.sort((a, b) => a.id > b.id ? -1 : 1).slice(0, ps.limit); ;
@@ -269,7 +269,12 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 			return true;
 		});
 
-		return feauturedNotes;
+		const packedFeauturedNotes = await this.noteEntityService.packMany(feauturedNotes, me, { withReactionAndUserPairCache: true });
+		await Promise.all(
+			packedFeauturedNotes.map(note => removeMutedUsersReactions(note, userIdsWhoMeMuting)),
+		);
+
+		return packedFeauturedNotes;
 	}
 
 	private async getFromDb(ps: { untilId: string | null; sinceId: string | null; limit: number; includeMyRenotes: boolean; includeRenotedMyNotes: boolean; includeLocalRenotes: boolean; withFiles: boolean; withRenotes: boolean; }, me: MiLocalUser) {

--- a/packages/backend/src/server/api/endpoints/notes/hanamisearch-v1.ts
+++ b/packages/backend/src/server/api/endpoints/notes/hanamisearch-v1.ts
@@ -1,8 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Endpoint } from '@/server/api/endpoint-base.js';
 import { HanamiSearchService } from '@/core/hanamisearch/HanamiSearchService.js';
-import { NoteEntityService } from '@/core/entities/NoteEntityService.js';
-import { isMustRemove } from '@/misc/is-hidden-or-visibility-modified.js';
 
 export const meta = {
 	tags: ['notes'],
@@ -53,11 +51,10 @@ export const paramDef = {
 @Injectable()
 export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-disable-line import/no-default-export
 	constructor(
-		private noteEntityService: NoteEntityService,
 		private hanamiSearchService: HanamiSearchService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
-			const notes = await this.hanamiSearchService.searchNote(ps.query, me, {
+			return await this.hanamiSearchService.searchNote(ps.query, me, {
 				userId: ps.userId,
 				channelId: ps.channelId,
 				host: ps.host,
@@ -68,7 +65,6 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				sinceId: ps.sinceId,
 				limit: ps.limit,
 			});
-			return (await this.noteEntityService.packMany(notes, me)).filter(note => !isMustRemove(note, 'home'));
 		});
 	}
 }

--- a/packages/backend/src/server/api/endpoints/notes/search.ts
+++ b/packages/backend/src/server/api/endpoints/notes/search.ts
@@ -6,9 +6,7 @@
 import { Injectable } from '@nestjs/common';
 import { Endpoint } from '@/server/api/endpoint-base.js';
 import { SearchService } from '@/core/SearchService.js';
-import { NoteEntityService } from '@/core/entities/NoteEntityService.js';
 import { RoleService } from '@/core/RoleService.js';
-import { isMustRemove } from '@/misc/is-hidden-or-visibility-modified.js';
 import { ApiError } from '../../error.js';
 
 export const meta = {
@@ -58,7 +56,6 @@ export const paramDef = {
 @Injectable()
 export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-disable-line import/no-default-export
 	constructor(
-		private noteEntityService: NoteEntityService,
 		private searchService: SearchService,
 		private roleService: RoleService,
 	) {
@@ -68,7 +65,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				throw new ApiError(meta.errors.unavailable);
 			}
 
-			const notes = await this.searchService.searchNote(ps.query, me, {
+			return await this.searchService.searchNote(ps.query, me, {
 				userId: ps.userId,
 				channelId: ps.channelId,
 				host: ps.host,
@@ -77,8 +74,6 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				sinceId: ps.sinceId,
 				limit: ps.limit,
 			});
-
-			return (await this.noteEntityService.packMany(notes, me)).filter(note => !isMustRemove(note, 'home'));
 		});
 	}
 }

--- a/packages/backend/src/server/api/endpoints/notes/show.ts
+++ b/packages/backend/src/server/api/endpoints/notes/show.ts
@@ -7,6 +7,8 @@ import { Injectable } from '@nestjs/common';
 import { Endpoint } from '@/server/api/endpoint-base.js';
 import { NoteEntityService } from '@/core/entities/NoteEntityService.js';
 import { GetterService } from '@/server/api/GetterService.js';
+import { CacheService } from '@/core/CacheService.js';
+import { removeMutedUsersReactions } from '@/misc/reactions-mute.js';
 import { ApiError } from '../../error.js';
 
 export const meta = {
@@ -47,6 +49,7 @@ export const paramDef = {
 export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-disable-line import/no-default-export
 	constructor(
 		private noteEntityService: NoteEntityService,
+		private cacheService: CacheService,
 		private getterService: GetterService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
@@ -59,9 +62,18 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				throw new ApiError(meta.errors.signinRequired);
 			}
 
-			return await this.noteEntityService.pack(note, me, {
+			const packedNote = await this.noteEntityService.pack(note, me, {
 				detail: true,
+				withReactionAndUserPairCache: true,
 			});
+
+			if (!me) {
+				delete packedNote.reactionAndUserPairCache;
+				return packedNote;
+			} else {
+				const userIdsWhoMeMuting = await this.cacheService.userMutingsCache.fetch(me.id);
+				return await removeMutedUsersReactions(packedNote, userIdsWhoMeMuting);
+			}
 		});
 	}
 }

--- a/packages/backend/src/server/api/endpoints/users/show.ts
+++ b/packages/backend/src/server/api/endpoints/users/show.ts
@@ -8,11 +8,13 @@ import { Inject, Injectable } from '@nestjs/common';
 import type { UsersRepository } from '@/models/_.js';
 import type { MiUser } from '@/models/User.js';
 import { Endpoint } from '@/server/api/endpoint-base.js';
+import { CacheService } from '@/core/CacheService.js';
 import { UserEntityService } from '@/core/entities/UserEntityService.js';
 import { RemoteUserResolveService } from '@/core/RemoteUserResolveService.js';
 import { DI } from '@/di-symbols.js';
 import PerUserPvChart from '@/core/chart/charts/per-user-pv.js';
 import { RoleService } from '@/core/RoleService.js';
+import { removeMutedUsersReactions } from '@/misc/reactions-mute.js';
 import { ApiError } from '../../error.js';
 import { ApiLoggerService } from '../../ApiLoggerService.js';
 import type { FindOptionsWhere } from 'typeorm';
@@ -85,6 +87,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		@Inject(DI.usersRepository)
 		private usersRepository: UsersRepository,
 
+		private cacheService: CacheService,
 		private userEntityService: UserEntityService,
 		private remoteUserResolveService: RemoteUserResolveService,
 		private roleService: RoleService,
@@ -147,9 +150,17 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 					}
 				}
 
-				return await this.userEntityService.pack(user, me, {
+				const packedUserProfile = await this.userEntityService.pack(user, me, {
 					schema: 'UserDetailed',
+					pinNotesWithReactionAndUserPairCache: true,
 				});
+				if (packedUserProfile.pinnedNotes.length > 0) {
+					const userIdsWhoMeMuting = await this.cacheService.userMutingsCache.fetch(user.id);
+					await Promise.all(
+						packedUserProfile.pinnedNotes.map(note => removeMutedUsersReactions(note, userIdsWhoMeMuting)),
+					);
+				}
+				return packedUserProfile;
 			}
 		});
 	}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- ストリーミングやnote/reactionsでは対応済みだったミュートした人のリアクションを表示しない機能の適用範囲を拡大

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
- packしてからでないと知れない情報をフィルタリングするためつらいがこれ以外の方法がなかった

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
