### PR TITLE
fix(icons-subsetter): 同じunicodeに複数のアイコンclassが割り当てられている場合に対応

### DIFF
--- a/packages/icons-subsetter/src/generator.ts
+++ b/packages/icons-subsetter/src/generator.ts
@@ -50,17 +50,11 @@ async function main() {
 		const files = await glob(dir, { cwd });
 		for (const file of files) {
 			//console.log(`Scanning ${file}`);
-			if (file.includes('MkSignin')) {
-				console.log(`Scanning ${file}`);
-			}
 			const content = await fsp.readFile(path.resolve(cwd, file), 'utf-8');
 			const classRegex = /ti-[a-z0-9-]+/g;
 			let matches: RegExpExecArray | null;
 			while ((matches = classRegex.exec(content)) !== null) {
 				const icon = matches[0];
-				if (file.includes('MkSignin')) {
-					console.log(`Found ${icon}, ${rgMap.has(icon)}`);
-				}
 				if (rgMap.has(icon)) {
 					iconsToPack.add(icon);
 				}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
非推奨になったclassを残しているなどの理由で、ひとつのunicodeに対して複数のアイコン名が割り当てられていた場合、両方のclassを出力するように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
ログイン画面の一部アイコンが消えてしまっていたため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
