### PR TITLE
hotfix: リノートの際リアクションしたノートが折りたたまれない問題を修正

### DIFF
--- a/packages/backend/src/misc/reactions-mute.ts
+++ b/packages/backend/src/misc/reactions-mute.ts
@@ -3,6 +3,7 @@ import { Packed } from '@/misc/json-schema.js';
 export async function removeMutedUsersReactions(
 	note: Packed<'Note'>,
 	userIdsWhoMeMuting: Set<string>,
+	removeReactionAndUserPairCache = true,
 ): Promise<Packed<'Note'>> {
 	// 指定されたオブジェクト（note または renote）に対して、
 	// ミュートされたユーザーのリアクションのカウントを差し引き、更新する
@@ -11,7 +12,7 @@ export async function removeMutedUsersReactions(
 		reactionAndUserPairCache?: string[];
 		reactionCount?: number;
 	}): void {
-		if (!target.reactions || !target.reactionAndUserPairCache) {
+		if (!target.reactions || !target.reactionAndUserPairCache && removeReactionAndUserPairCache) {
 			delete target.reactionAndUserPairCache;
 			return;
 		}
@@ -19,14 +20,16 @@ export async function removeMutedUsersReactions(
 		// ミュート対象ユーザーからの各リアクションの合計数を集計
 		const mutedCounts: Record<string, number> = Object.create(null);
 		const cache = target.reactionAndUserPairCache;
-		for (let i = 0, len = cache.length; i < len; i++) {
-			const entry = cache[i];
-			const sep = entry.indexOf('/');
-			if (sep === -1) continue;
-			const userId = entry.slice(0, sep);
-			const reaction = entry.slice(sep + 1);
-			if (userId && reaction && userIdsWhoMeMuting.has(userId)) {
-				mutedCounts[reaction] = (mutedCounts[reaction] || 0) + 1;
+		if (cache) {
+			for (let i = 0, len = cache.length; i < len; i++) {
+				const entry = cache[i];
+				const sep = entry.indexOf('/');
+				if (sep === -1) continue;
+				const userId = entry.slice(0, sep);
+				const reaction = entry.slice(sep + 1);
+				if (userId && reaction && userIdsWhoMeMuting.has(userId)) {
+					mutedCounts[reaction] = (mutedCounts[reaction] || 0) + 1;
+				}
 			}
 		}
 
@@ -48,7 +51,9 @@ export async function removeMutedUsersReactions(
 		}
 
 		// キャッシュは不要になったため削除
-		delete target.reactionAndUserPairCache;
+		if (removeReactionAndUserPairCache) {
+			delete target.reactionAndUserPairCache;
+		}
 	}
 
 	// note と renote（存在する場合）に対して処理を適用

--- a/packages/backend/src/server/api/stream/channel.ts
+++ b/packages/backend/src/server/api/stream/channel.ts
@@ -79,7 +79,7 @@ export default abstract class Channel {
 	}
 
 	protected async removeMutedReactions(note: Packed<'Note'>): Promise<Packed<'Note'>> {
-		return await removeMutedUsersReactions(note, this.userIdsWhoMeMuting);
+		return await removeMutedUsersReactions(note, this.userIdsWhoMeMuting, false);
 	}
 
 	constructor(id: string, connection: Connection) {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- ストリーミングにはreactionUserPairCacheを乗せる


## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
- この実装だと一つの関数が、ミュート処理とreactionUserPairCacheの処遇を決める処理を行うので良くない
- これで問題が発生しなくなることを確認したあとリファクタリングする

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
