### PR TITLE
Fix reaction cache filter for muted users

### DIFF
--- a/packages/backend/src/misc/reactions-mute.ts
+++ b/packages/backend/src/misc/reactions-mute.ts
@@ -12,34 +12,34 @@ export async function removeMutedUsersReactions(
 		reactionAndUserPairCache?: string[];
 		reactionCount?: number;
 	}): void {
-                if (!target.reactions) return;
+		if (!target.reactions) return;
 
-                const cache = target.reactionAndUserPairCache;
-                if (!cache) {
-                        if (removeReactionAndUserPairCache) delete target.reactionAndUserPairCache;
-                        return;
-                }
+		const cache = target.reactionAndUserPairCache;
+		if (!cache) {
+			if (removeReactionAndUserPairCache) delete target.reactionAndUserPairCache;
+			return;
+		}
 
 		// ミュート対象ユーザーからの各リアクションの合計数を集計
-                const mutedCounts: Record<string, number> = Object.create(null);
-                const filtered: string[] = [];
+		const mutedCounts: Record<string, number> = Object.create(null);
+		const filtered: string[] = [];
 
-                for (let i = 0, len = cache.length; i < len; i++) {
-                        const entry = cache[i];
-                        const sep = entry.indexOf('/');
-                        if (sep === -1) {
-                                filtered.push(entry);
-                                continue;
-                        }
-                        const userId = entry.slice(0, sep);
-                        const reaction = entry.slice(sep + 1);
+		for (let i = 0, len = cache.length; i < len; i++) {
+			const entry = cache[i];
+			const sep = entry.indexOf('/');
+			if (sep === -1) {
+				filtered.push(entry);
+				continue;
+			}
+			const userId = entry.slice(0, sep);
+			const reaction = entry.slice(sep + 1);
 
-                        if (userId && reaction && userIdsWhoMeMuting.has(userId)) {
-                                mutedCounts[reaction] = (mutedCounts[reaction] || 0) + 1;
-                        } else {
-                                filtered.push(entry);
-                        }
-                }
+			if (userId && reaction && userIdsWhoMeMuting.has(userId)) {
+				mutedCounts[reaction] = (mutedCounts[reaction] || 0) + 1;
+			} else {
+				filtered.push(entry);
+			}
+		}
 
 		// 集計結果に基づき、対象のリアクションカウントからミュート分を減算
 		const keys = Object.keys(target.reactions);
@@ -58,13 +58,13 @@ export async function removeMutedUsersReactions(
 			}
 		}
 
-                // キャッシュを更新
-                if (removeReactionAndUserPairCache) {
-                        delete target.reactionAndUserPairCache;
-                } else {
-                        target.reactionAndUserPairCache = filtered;
-                }
-        }
+		// キャッシュを更新
+		if (removeReactionAndUserPairCache) {
+			delete target.reactionAndUserPairCache;
+		} else {
+			target.reactionAndUserPairCache = filtered;
+		}
+	}
 
 	// note と renote（存在する場合）に対して処理を適用
 	removeMutedUserReactionCounts(note);

--- a/packages/backend/src/misc/reactions-mute.ts
+++ b/packages/backend/src/misc/reactions-mute.ts
@@ -12,26 +12,34 @@ export async function removeMutedUsersReactions(
 		reactionAndUserPairCache?: string[];
 		reactionCount?: number;
 	}): void {
-		if (!target.reactions || !target.reactionAndUserPairCache && removeReactionAndUserPairCache) {
-			delete target.reactionAndUserPairCache;
-			return;
-		}
+                if (!target.reactions) return;
+
+                const cache = target.reactionAndUserPairCache;
+                if (!cache) {
+                        if (removeReactionAndUserPairCache) delete target.reactionAndUserPairCache;
+                        return;
+                }
 
 		// ミュート対象ユーザーからの各リアクションの合計数を集計
-		const mutedCounts: Record<string, number> = Object.create(null);
-		const cache = target.reactionAndUserPairCache;
-		if (cache) {
-			for (let i = 0, len = cache.length; i < len; i++) {
-				const entry = cache[i];
-				const sep = entry.indexOf('/');
-				if (sep === -1) continue;
-				const userId = entry.slice(0, sep);
-				const reaction = entry.slice(sep + 1);
-				if (userId && reaction && userIdsWhoMeMuting.has(userId)) {
-					mutedCounts[reaction] = (mutedCounts[reaction] || 0) + 1;
-				}
-			}
-		}
+                const mutedCounts: Record<string, number> = Object.create(null);
+                const filtered: string[] = [];
+
+                for (let i = 0, len = cache.length; i < len; i++) {
+                        const entry = cache[i];
+                        const sep = entry.indexOf('/');
+                        if (sep === -1) {
+                                filtered.push(entry);
+                                continue;
+                        }
+                        const userId = entry.slice(0, sep);
+                        const reaction = entry.slice(sep + 1);
+
+                        if (userId && reaction && userIdsWhoMeMuting.has(userId)) {
+                                mutedCounts[reaction] = (mutedCounts[reaction] || 0) + 1;
+                        } else {
+                                filtered.push(entry);
+                        }
+                }
 
 		// 集計結果に基づき、対象のリアクションカウントからミュート分を減算
 		const keys = Object.keys(target.reactions);
@@ -50,11 +58,13 @@ export async function removeMutedUsersReactions(
 			}
 		}
 
-		// キャッシュは不要になったため削除
-		if (removeReactionAndUserPairCache) {
-			delete target.reactionAndUserPairCache;
-		}
-	}
+                // キャッシュを更新
+                if (removeReactionAndUserPairCache) {
+                        delete target.reactionAndUserPairCache;
+                } else {
+                        target.reactionAndUserPairCache = filtered;
+                }
+        }
 
 	// note と renote（存在する場合）に対して処理を適用
 	removeMutedUserReactionCounts(note);

--- a/packages/backend/src/server/api/stream/channel.ts
+++ b/packages/backend/src/server/api/stream/channel.ts
@@ -8,6 +8,7 @@ import { isInstanceMuted } from '@/misc/is-instance-muted.js';
 import { isUserRelated } from '@/misc/is-user-related.js';
 import { isRenotePacked, isQuotePacked } from '@/misc/is-renote.js';
 import { removeMutedUsersReactions } from '@/misc/reactions-mute.js';
+import { deepClone } from '@/misc/clone.js';
 import type { Packed } from '@/misc/json-schema.js';
 import type { JsonObject, JsonValue } from '@/misc/json-value.js';
 import type Connection from './Connection.js';
@@ -79,7 +80,8 @@ export default abstract class Channel {
 	}
 
 	protected async removeMutedReactions(note: Packed<'Note'>): Promise<Packed<'Note'>> {
-		return await removeMutedUsersReactions(note, this.userIdsWhoMeMuting, false);
+		const cloned = deepClone(note);
+		return await removeMutedUsersReactions(cloned, this.userIdsWhoMeMuting, false);
 	}
 
 	constructor(id: string, connection: Connection) {

--- a/packages/backend/src/server/api/stream/channels/global-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/global-timeline.ts
@@ -58,14 +58,14 @@ class GlobalTimelineChannel extends Channel {
 
 		if (this.isNoteMutedOrBlocked(note)) return;
 
-		if (this.user && isRenotePacked(note) && !isQuotePacked(note)) {
-			if (note.renote && Object.keys(note.renote.reactions).length > 0) {
-				const myRenoteReaction = await this.noteEntityService.populateMyReaction(note.renote, this.user.id);
-				note.renote.myReaction = myRenoteReaction;
+		const reactionMutedNote = await this.removeMutedReactions(note);
+
+		if (this.user && isRenotePacked(reactionMutedNote) && !isQuotePacked(reactionMutedNote)) {
+			if (reactionMutedNote.renote && Object.keys(reactionMutedNote.renote.reactions).length > 0) {
+				const myRenoteReaction = await this.noteEntityService.populateMyReaction(reactionMutedNote.renote, this.user.id);
+				reactionMutedNote.renote.myReaction = myRenoteReaction;
 			}
 		}
-
-		const reactionMutedNote = await this.removeMutedReactions(note);
 
 		this.connection.cacheNote(reactionMutedNote);
 

--- a/packages/backend/src/server/api/stream/channels/hanami-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/hanami-timeline.ts
@@ -117,14 +117,14 @@ class HanamiTimelineChannel extends Channel {
 
 		if (this.isNoteMutedOrBlocked(note)) return;
 
-		if (this.user && isRenotePacked(note) && !isQuotePacked(note)) {
-			if (note.renote && Object.keys(note.renote.reactions).length > 0) {
-				const myRenoteReaction = await this.noteEntityService.populateMyReaction(note.renote, this.user.id);
-				note.renote.myReaction = myRenoteReaction;
+		const reactionMutedNote = await this.removeMutedReactions(note);
+
+		if (this.user && isRenotePacked(reactionMutedNote) && !isQuotePacked(reactionMutedNote)) {
+			if (reactionMutedNote.renote && Object.keys(reactionMutedNote.renote.reactions).length > 0) {
+				const myRenoteReaction = await this.noteEntityService.populateMyReaction(reactionMutedNote.renote, this.user.id);
+				reactionMutedNote.renote.myReaction = myRenoteReaction;
 			}
 		}
-
-		const reactionMutedNote = await this.removeMutedReactions(note);
 
 		this.connection.cacheNote(reactionMutedNote);
 

--- a/packages/backend/src/server/api/stream/channels/hashtag.ts
+++ b/packages/backend/src/server/api/stream/channels/hashtag.ts
@@ -46,14 +46,14 @@ class HashtagChannel extends Channel {
 
 		if (this.isNoteMutedOrBlocked(note)) return;
 
-		if (this.user && isRenotePacked(note) && !isQuotePacked(note)) {
-			if (note.renote && Object.keys(note.renote.reactions).length > 0) {
-				const myRenoteReaction = await this.noteEntityService.populateMyReaction(note.renote, this.user.id);
-				note.renote.myReaction = myRenoteReaction;
+		const reactionMutedNote = await this.removeMutedReactions(note);
+
+		if (this.user && isRenotePacked(reactionMutedNote) && !isQuotePacked(reactionMutedNote)) {
+			if (reactionMutedNote.renote && Object.keys(reactionMutedNote.renote.reactions).length > 0) {
+				const myRenoteReaction = await this.noteEntityService.populateMyReaction(reactionMutedNote.renote, this.user.id);
+				reactionMutedNote.renote.myReaction = myRenoteReaction;
 			}
 		}
-
-		const reactionMutedNote = await this.removeMutedReactions(note);
 
 		this.connection.cacheNote(reactionMutedNote);
 

--- a/packages/backend/src/server/api/stream/channels/home-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/home-timeline.ts
@@ -79,14 +79,14 @@ class HomeTimelineChannel extends Channel {
 
 		if (this.isNoteMutedOrBlocked(note)) return;
 
-		if (this.user && isRenotePacked(note) && !isQuotePacked(note)) {
-			if (note.renote && Object.keys(note.renote.reactions).length > 0) {
-				const myRenoteReaction = await this.noteEntityService.populateMyReaction(note.renote, this.user.id);
-				note.renote.myReaction = myRenoteReaction;
+		const reactionMutedNote = await this.removeMutedReactions(note);
+
+		if (this.user && isRenotePacked(reactionMutedNote) && !isQuotePacked(reactionMutedNote)) {
+			if (reactionMutedNote.renote && Object.keys(reactionMutedNote.renote.reactions).length > 0) {
+				const myRenoteReaction = await this.noteEntityService.populateMyReaction(reactionMutedNote.renote, this.user.id);
+				reactionMutedNote.renote.myReaction = myRenoteReaction;
 			}
 		}
-
-		const reactionMutedNote = await this.removeMutedReactions(note);
 
 		this.connection.cacheNote(reactionMutedNote);
 

--- a/packages/backend/src/server/api/stream/channels/hybrid-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/hybrid-timeline.ts
@@ -98,14 +98,14 @@ class HybridTimelineChannel extends Channel {
 			}
 		}
 
-		if (this.user && note.renoteId && !note.text) {
-			if (note.renote && Object.keys(note.renote.reactions).length > 0) {
-				const myRenoteReaction = await this.noteEntityService.populateMyReaction(note.renote, this.user.id);
-				note.renote.myReaction = myRenoteReaction;
+		const reactionMutedNote = await this.removeMutedReactions(note);
+
+		if (this.user && reactionMutedNote.renoteId && !reactionMutedNote.text) {
+			if (reactionMutedNote.renote && Object.keys(reactionMutedNote.renote.reactions).length > 0) {
+				const myRenoteReaction = await this.noteEntityService.populateMyReaction(reactionMutedNote.renote, this.user.id);
+				reactionMutedNote.renote.myReaction = myRenoteReaction;
 			}
 		}
-
-		const reactionMutedNote = await this.removeMutedReactions(note);
 
 		this.connection.cacheNote(reactionMutedNote);
 

--- a/packages/backend/src/server/api/stream/channels/local-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/local-timeline.ts
@@ -69,14 +69,14 @@ class LocalTimelineChannel extends Channel {
 
 		if (this.isNoteMutedOrBlocked(note)) return;
 
-		if (this.user && isRenotePacked(note) && !isQuotePacked(note)) {
-			if (note.renote && Object.keys(note.renote.reactions).length > 0) {
-				const myRenoteReaction = await this.noteEntityService.populateMyReaction(note.renote, this.user.id);
-				note.renote.myReaction = myRenoteReaction;
+		const reactionMutedNote = await this.removeMutedReactions(note);
+
+		if (this.user && isRenotePacked(reactionMutedNote) && !isQuotePacked(reactionMutedNote)) {
+			if (reactionMutedNote.renote && Object.keys(reactionMutedNote.renote.reactions).length > 0) {
+				const myRenoteReaction = await this.noteEntityService.populateMyReaction(reactionMutedNote.renote, this.user.id);
+				reactionMutedNote.renote.myReaction = myRenoteReaction;
 			}
 		}
-
-		const reactionMutedNote = await this.removeMutedReactions(note);
 
 		this.connection.cacheNote(reactionMutedNote);
 


### PR DESCRIPTION
## Summary
- remove muted users' entries from `reactionAndUserPairCache`
- keep the cache after filtering for streaming

## Testing
- `pnpm jest` *(fails: Connect Timeout Error)*

------
https://chatgpt.com/codex/tasks/task_e_683a39bff9288326a8d8da0baf735ced