### PR TITLE
Fix reaction cache filter for muted users

### DIFF
--- a/packages/backend/src/core/entities/NoteEntityService.ts
+++ b/packages/backend/src/core/entities/NoteEntityService.ts
@@ -249,7 +249,7 @@ export class NoteEntityService implements OnModuleInit {
 		const reactionsCount = Object.values(note.reactions).reduce((a, b) => a + b, 0);
 		if (reactionsCount === 0) return undefined;
 		if (note.reactionAndUserPairCache && reactionsCount <= note.reactionAndUserPairCache.length) {
-			const pair = note.reactionAndUserPairCache.find(p => p.startsWith(meId));
+                        const pair = note.reactionAndUserPairCache.find(p => p.startsWith(meId + '/'));
 			if (pair) {
 				return this.reactionService.convertLegacyReaction(pair.split('/')[1]);
 			} else {
@@ -503,7 +503,7 @@ export class NoteEntityService implements OnModuleInit {
 						if (pairInBuffer) {
 							myReactionsMap.set(note.renote.id, pairInBuffer[1]);
 						} else {
-							const pair = note.renote.reactionAndUserPairCache.find(p => p.startsWith(meId));
+                                                        const pair = note.renote.reactionAndUserPairCache.find(p => p.startsWith(meId + '/'));
 							myReactionsMap.set(note.renote.id, pair ? pair.split('/')[1] : null);
 						}
 					} else {
@@ -519,7 +519,7 @@ export class NoteEntityService implements OnModuleInit {
 							if (pairInBuffer) {
 								myReactionsMap.set(note.id, pairInBuffer[1]);
 							} else {
-								const pair = note.reactionAndUserPairCache.find(p => p.startsWith(meId));
+                                                        const pair = note.reactionAndUserPairCache.find(p => p.startsWith(meId + '/'));
 								myReactionsMap.set(note.id, pair ? pair.split('/')[1] : null);
 							}
 						} else {

--- a/packages/backend/src/misc/reactions-mute.ts
+++ b/packages/backend/src/misc/reactions-mute.ts
@@ -12,26 +12,34 @@ export async function removeMutedUsersReactions(
 		reactionAndUserPairCache?: string[];
 		reactionCount?: number;
 	}): void {
-		if (!target.reactions || !target.reactionAndUserPairCache && removeReactionAndUserPairCache) {
-			delete target.reactionAndUserPairCache;
-			return;
-		}
+                if (!target.reactions) return;
+
+                const cache = target.reactionAndUserPairCache;
+                if (!cache) {
+                        if (removeReactionAndUserPairCache) delete target.reactionAndUserPairCache;
+                        return;
+                }
 
 		// ミュート対象ユーザーからの各リアクションの合計数を集計
-		const mutedCounts: Record<string, number> = Object.create(null);
-		const cache = target.reactionAndUserPairCache;
-		if (cache) {
-			for (let i = 0, len = cache.length; i < len; i++) {
-				const entry = cache[i];
-				const sep = entry.indexOf('/');
-				if (sep === -1) continue;
-				const userId = entry.slice(0, sep);
-				const reaction = entry.slice(sep + 1);
-				if (userId && reaction && userIdsWhoMeMuting.has(userId)) {
-					mutedCounts[reaction] = (mutedCounts[reaction] || 0) + 1;
-				}
-			}
-		}
+                const mutedCounts: Record<string, number> = Object.create(null);
+                const filtered: string[] = [];
+
+                for (let i = 0, len = cache.length; i < len; i++) {
+                        const entry = cache[i];
+                        const sep = entry.indexOf('/');
+                        if (sep === -1) {
+                                filtered.push(entry);
+                                continue;
+                        }
+                        const userId = entry.slice(0, sep);
+                        const reaction = entry.slice(sep + 1);
+
+                        if (userId && reaction && userIdsWhoMeMuting.has(userId)) {
+                                mutedCounts[reaction] = (mutedCounts[reaction] || 0) + 1;
+                        } else {
+                                filtered.push(entry);
+                        }
+                }
 
 		// 集計結果に基づき、対象のリアクションカウントからミュート分を減算
 		const keys = Object.keys(target.reactions);
@@ -50,11 +58,13 @@ export async function removeMutedUsersReactions(
 			}
 		}
 
-		// キャッシュは不要になったため削除
-		if (removeReactionAndUserPairCache) {
-			delete target.reactionAndUserPairCache;
-		}
-	}
+                // キャッシュを更新
+                if (removeReactionAndUserPairCache) {
+                        delete target.reactionAndUserPairCache;
+                } else {
+                        target.reactionAndUserPairCache = filtered;
+                }
+        }
 
 	// note と renote（存在する場合）に対して処理を適用
 	removeMutedUserReactionCounts(note);


### PR DESCRIPTION
## Summary
- remove muted users' entries from `reactionAndUserPairCache`
- keep the cache after filtering for streaming
- avoid ID prefix collisions when locating my reaction

## Testing
- `pnpm jest` *(fails: Connect Timeout Error)*

------
https://chatgpt.com/codex/tasks/task_e_683a39bff9288326a8d8da0baf735ced