### PR TITLE
Improve emoji mute behavior

### DIFF
--- a/packages/frontend/src/components/MkEmojiPicker.vue
+++ b/packages/frontend/src/components/MkEmojiPicker.vue
@@ -91,8 +91,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 				v-for="child in customEmojiFolderRoot.children"
 				:key="`custom:${child.value}`"
 				:initialShown="false"
-				:emojis="computed(() => customEmojis.filter(e => filterCategory(e, child.value)).map(e => `:${e.name}:`))"
-				:disabledEmojis="computed(() => customEmojis.filter(e => filterCategory(e, child.value)).filter(e => !canReact(e)).map(e => `:${e.name}:`))"
+                                :emojis="computed(() => availableCustomEmojis.value.filter(e => filterCategory(e, child.value)).map(e => `:${e.name}:`))"
+                                :disabledEmojis="computed(() => availableCustomEmojis.value.filter(e => filterCategory(e, child.value)).filter(e => !canReact(e)).map(e => `:${e.name}:`))"
 				:hasChildSection="child.children.length !== 0"
 				:customEmojiTree="child.children"
 				@chosen="chosen"
@@ -136,6 +136,7 @@ import { deviceKind } from '@/utility/device-kind.js';
 import { i18n } from '@/i18n.js';
 import { store } from '@/store.js';
 import { customEmojiCategories, customEmojis, customEmojisMap } from '@/custom-emojis.js';
+import { mutedEmojis } from '@/muted-emojis.js';
 import { $i } from '@/i.js';
 import { romajiIncludes } from '@/hana/scripts/romaji-includes.js';
 import { searchCustomEmojis } from '@/hana/scripts/emoji-search.js';
@@ -172,11 +173,19 @@ const {
 const recentlyUsedEmojis = store.r.recentlyUsedEmojis;
 
 const recentlyUsedEmojisDef = computed(() => {
-	return recentlyUsedEmojis.value.map(getDef);
+        return recentlyUsedEmojis.value
+                .filter(e => !mutedEmojis.value.includes(e.replace(/:/g, '')))
+                .map(getDef);
 });
 const pinnedEmojisDef = computed(() => {
-	return pinned.value?.map(getDef);
+        return pinned.value
+                ?.filter(e => !mutedEmojis.value.includes(e.replace(/:/g, '')))
+                .map(getDef);
 });
+
+const availableCustomEmojis = computed(() =>
+        customEmojis.value.filter(e => !mutedEmojis.value.includes(e.name))
+);
 
 const pinned = computed(() => props.pinnedEmojis);
 const size = computed(() => emojiPickerScale.value);
@@ -229,7 +238,7 @@ watch(q, async () => {
 
 	const searchCustom = () => {
 		const max = 100;
-		const emojis = customEmojis.value;
+                const emojis = availableCustomEmojis.value;
 		const matches = new Set<Misskey.entities.EmojiSimple>();
 
 		const exactMatch = emojis.find(emoji => emoji.name === newQ);
@@ -381,8 +390,8 @@ watch(q, async () => {
 		}
 	}
 
-	searchResultCustom.value = await _searchCustom();
-	searchResultUnicode.value = Array.from(searchUnicode());
+        searchResultCustom.value = (await _searchCustom()).filter(e => !mutedEmojis.value.includes(e.name));
+        searchResultUnicode.value = Array.from(searchUnicode());
 });
 
 function canReact(emoji: Misskey.entities.EmojiSimple | UnicodeEmojiDef | string): boolean {

--- a/packages/frontend/src/components/MkReactionsViewer.reaction.vue
+++ b/packages/frontend/src/components/MkReactionsViewer.reaction.vue
@@ -5,10 +5,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <template>
 <button
-	ref="buttonEl"
-	v-ripple="canToggle"
-	class="_button"
-	:class="[$style.root, { [$style.reacted]: note.myReaction == reaction, [$style.canToggle]: canToggle, [$style.small]: prefer.s.reactionsDisplaySize === 'small', [$style.large]: prefer.s.reactionsDisplaySize === 'large' }]"
+        ref="buttonEl"
+        v-ripple="canToggle"
+        class="_button"
+        :class="[$style.root, { [$style.reacted]: displayMyReaction === reaction, [$style.canToggle]: canToggle, [$style.small]: prefer.s.reactionsDisplaySize === 'small', [$style.large]: prefer.s.reactionsDisplaySize === 'large' }]"
 	@click="toggleReaction()"
 	@contextmenu.prevent.stop="menu"
 >
@@ -38,10 +38,11 @@ import { prefer } from '@/preferences.js';
 import { DI } from '@/di.js';
 
 const props = defineProps<{
-	reaction: string;
-	count: number;
-	isInitial: boolean;
-	note: Misskey.entities.Note;
+        reaction: string;
+        count: number;
+        isInitial: boolean;
+        note: Misskey.entities.Note;
+        displayMyReaction: string | null;
 }>();
 
 const mock = inject(DI.mock, false);

--- a/packages/frontend/src/components/MkReactionsViewer.vue
+++ b/packages/frontend/src/components/MkReactionsViewer.vue
@@ -13,17 +13,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 	:moveClass="$style.transition_x_move"
 	tag="div" :class="$style.root"
 >
-	<XReaction v-for="[reaction, count] in reactions" :key="reaction" :reaction="reaction" :count="count" :isInitial="initialReactions.has(reaction)" :note="note" @reactionToggled="onMockToggleReaction"/>
+       <XReaction v-for="[reaction, count] in reactions" :key="reaction" :reaction="reaction" :count="count" :isInitial="initialReactions.value.has(reaction)" :note="note" :displayMyReaction="displayMyReaction" @reactionToggled="onMockToggleReaction"/>
 	<slot v-if="hasMoreReactions" name="more"/>
 </component>
 </template>
 
 <script lang="ts" setup>
 import * as Misskey from 'misskey-js';
-import { inject, watch, ref } from 'vue';
+import { inject, watch, ref, computed } from 'vue';
 import { TransitionGroup } from 'vue';
 import XReaction from '@/components/MkReactionsViewer.reaction.vue';
 import { prefer } from '@/preferences.js';
+import { mutedEmojis } from '@/muted-emojis.js';
 import { DI } from '@/di.js';
 
 const props = withDefaults(defineProps<{
@@ -39,13 +40,32 @@ const emit = defineEmits<{
 	(ev: 'mockUpdateMyReaction', emoji: string, delta: number): void;
 }>();
 
-const initialReactions = new Set(Object.keys(props.note.reactions));
+const displayReactionsSource = computed(() => {
+        const res: Record<string, number> = {};
+        for (const [k, v] of Object.entries(props.note.reactions)) {
+                const name = k.replace(/:/g, '').replace(/@\./, '');
+                if (mutedEmojis.value.includes(name)) {
+                        res['❤️'] = (res['❤️'] || 0) + v;
+                } else {
+                        res[k] = v;
+                }
+        }
+        return res;
+});
+
+const initialReactions = computed(() => new Set(Object.keys(displayReactionsSource.value)));
+
+const displayMyReaction = computed(() => {
+        if (!props.note.myReaction) return null;
+        const name = props.note.myReaction.replace(/:/g, '').replace(/@\./, '');
+        return mutedEmojis.value.includes(name) ? '❤️' : props.note.myReaction;
+});
 
 const reactions = ref<[string, number][]>([]);
 const hasMoreReactions = ref(false);
 
-if (props.note.myReaction && !Object.keys(reactions.value).includes(props.note.myReaction)) {
-	reactions.value[props.note.myReaction] = props.note.reactions[props.note.myReaction];
+if (displayMyReaction.value && !Object.keys(reactions.value).includes(displayMyReaction.value)) {
+        reactions.value[displayMyReaction.value] = displayReactionsSource.value[displayMyReaction.value];
 }
 
 function onMockToggleReaction(emoji: string, count: number) {
@@ -57,9 +77,9 @@ function onMockToggleReaction(emoji: string, count: number) {
 	emit('mockUpdateMyReaction', emoji, (count - reactions.value[i][1]));
 }
 
-watch([() => props.note.reactions, () => props.maxNumber], ([newSource, maxNumber]) => {
+watch([displayReactionsSource, () => props.maxNumber], ([newSource, maxNumber]) => {
 	let newReactions: [string, number][] = [];
-	hasMoreReactions.value = Object.keys(newSource).length > maxNumber;
+        hasMoreReactions.value = Object.keys(newSource).length > maxNumber;
 
 	for (let i = 0; i < reactions.value.length; i++) {
 		const reaction = reactions.value[i][0];
@@ -79,9 +99,9 @@ watch([() => props.note.reactions, () => props.maxNumber], ([newSource, maxNumbe
 
 	newReactions = newReactions.slice(0, props.maxNumber);
 
-	if (props.note.myReaction && !newReactions.map(([x]) => x).includes(props.note.myReaction)) {
-		newReactions.push([props.note.myReaction, newSource[props.note.myReaction]]);
-	}
+        if (displayMyReaction.value && !newReactions.map(([x]) => x).includes(displayMyReaction.value)) {
+                newReactions.push([displayMyReaction.value, newSource[displayMyReaction.value]]);
+        }
 
 	reactions.value = newReactions;
 }, { immediate: true, deep: true });

--- a/packages/frontend/src/muted-emojis.ts
+++ b/packages/frontend/src/muted-emojis.ts
@@ -1,0 +1,22 @@
+import { shallowRef } from 'vue';
+import { miLocalStorage } from '@/local-storage.js';
+
+const KEY = 'mutedEmojis';
+
+function load(): string[] {
+        const value = miLocalStorage.getItem(KEY);
+        if (!value) return [];
+        try {
+                const parsed = JSON.parse(value);
+                return Array.isArray(parsed) ? parsed : [];
+        } catch {
+                return [];
+        }
+}
+
+export const mutedEmojis = shallowRef<string[]>(load());
+
+export function setMutedEmojis(emojis: string[]) {
+        mutedEmojis.value = emojis;
+        miLocalStorage.setItem(KEY, JSON.stringify(emojis));
+}


### PR DESCRIPTION
## Summary
- add muted emoji storage
- hide muted emojis in the picker
- merge muted reactions into a heart
- ensure reaction viewer initializes correctly

## Testing
- `pnpm lint` *(fails: Cannot find module 'misskey-js' in packages/sw)*
- `pnpm -r test` *(fails: misskey-js tsd missing built file)*

------
https://chatgpt.com/codex/tasks/task_e_6845584cdcbc8326b1917e6a1ead7794