### PR TITLE
enhance&fix: ノート検索のフィルタ条件の見直し+0件で返してページネーションに失敗しないように

### DIFF
--- a/packages/backend/src/core/hanamisearch/HanamiSearchService.ts
+++ b/packages/backend/src/core/hanamisearch/HanamiSearchService.ts
@@ -4,24 +4,32 @@
  */
 
 import { Inject, Injectable } from '@nestjs/common';
-import { In } from 'typeorm';
 import { DI } from '@/di-symbols.js';
 import type { Config } from '@/config.js';
 import { bindThis } from '@/decorators.js';
 import { Packed } from '@/misc/json-schema.js';
 import { MiNote } from '@/models/Note.js';
-import { MiUser } from '@/models/_.js';
+import { MiMeta, MiUser } from '@/models/_.js';
 import type { NotesRepository } from '@/models/_.js';
 import { isUserRelated } from '@/misc/is-user-related.js';
+import { isInstanceMuted } from '@/misc/is-instance-muted.js';
 import { CacheService } from '@/core/CacheService.js';
 import { IdService } from '@/core/IdService.js';
+import { UtilityService } from '@/core/UtilityService.js';
 import { isMustRemove } from '@/misc/is-hidden-or-visibility-modified.js';
 import { NoteEntityService } from '@/core/entities/NoteEntityService.js';
 import { removeMutedUsersReactions } from '@/misc/reactions-mute.js';
 import type { Index, MeiliSearch } from 'meilisearch';
 
+const SEARCH_EMPTY_PAGE_RETRY_LIMIT = 5;
+
 type K = string;
 type V = string | number | boolean;
+type SearchUserFilters = {
+	userIdsWhoMeMuting: Set<string>;
+	userIdsWhoBlockingMe: Set<string>;
+	userMutedInstances: Set<string>;
+};
 type Q =
 	{ op: '=', k: K, v: V } |
 	{ op: '!=', k: K, v: V } |
@@ -78,9 +86,13 @@ export class HanamiSearchService {
 		@Inject(DI.notesRepository)
 		private notesRepository: NotesRepository,
 
+		@Inject(DI.meta)
+		private meta: MiMeta,
+
 		private noteEntityService: NoteEntityService,
 		private cacheService: CacheService,
 		private idService: IdService,
+		private utilityService: UtilityService,
 	) {
 		this.hanamisearchIndexScope = config.hanamisearch?.scope || 'global';
 
@@ -221,37 +233,104 @@ export class HanamiSearchService {
 		}
 		if (opts.onlyWithFiles) filter.qs.push({ op: 'is not null', k: 'fileIds' });
 
-		const res = await searchClient.search(q, {
-			sort: shouldTimeSeriesSort ? ['createdAt:desc'] : undefined,
-			matchingStrategy: 'all',
-			attributesToRetrieve: ['id', 'createdAt'],
-			filter: compileQuery(filter),
-			limit: pagination.limit,
-		});
+		const limit = pagination.limit ?? 10;
+		const compiledFilter = compileQuery(filter);
 
-		if (res.hits.length === 0) return [];
+		const searchNext = async (
+			offset: number,
+			remainingRetries: number,
+			userFilters: SearchUserFilters | null,
+		): Promise<Packed<'Note'>[]> => {
+			if (remainingRetries <= 0) return [];
 
-		const [userIdsWhoMeMuting, userIdsWhoBlockingMe] = me
-			? await Promise.all([
-				this.cacheService.userMutingsCache.fetch(me.id),
-				this.cacheService.userBlockedCache.fetch(me.id),
-			])
-			: [new Set<string>(), new Set<string>()];
+			const res = await searchClient.search(q, {
+				sort: shouldTimeSeriesSort ? ['createdAt:desc'] : undefined,
+				matchingStrategy: 'all',
+				attributesToRetrieve: ['id', 'createdAt'],
+				filter: compiledFilter,
+				limit,
+				offset,
+			});
 
-		const notes = (await this.notesRepository.findBy({
-			id: In(res.hits.map((x) => x.id)),
-		})).filter((note) => {
-			if (me && isUserRelated(note, userIdsWhoBlockingMe)) return false;
-			if (me && isUserRelated(note, userIdsWhoMeMuting)) return false;
-			return true;
-		});
+			if (res.hits.length === 0) return [];
 
-		notes.sort((a, b) => a.id > b.id ? -1 : 1);
-		const packedNotes = (await this.noteEntityService.packMany(notes, me, { withReactionAndUserPairCache: true })).filter(note => !isMustRemove(note, 'home'));
-		await Promise.all(
-			packedNotes.map(note => removeMutedUsersReactions(note, userIdsWhoMeMuting)),
-		);
+			const query = this.notesRepository.createQueryBuilder('note')
+				.innerJoinAndSelect('note.user', 'user')
+				.leftJoinAndSelect('note.reply', 'reply')
+				.leftJoinAndSelect('note.renote', 'renote')
+				.leftJoinAndSelect('reply.user', 'replyUser')
+				.leftJoinAndSelect('renote.user', 'renoteUser');
 
-		return packedNotes;
+			query.where('note.id IN (:...noteIds)', { noteIds: res.hits.map(x => x.id) });
+
+			const rawNotes = await query.getMany();
+			const nextUserFilters = me && rawNotes.length > 0
+				? userFilters ?? await this.fetchSearchUserFilters(me)
+				: userFilters;
+
+			const notes = rawNotes.filter((note) => {
+				if (this.utilityService.isBlockedHost(this.meta.blockedHosts, note.userHost)) return false;
+				if (note.userId !== note.renoteUserId && this.utilityService.isBlockedHost(this.meta.blockedHosts, note.renoteUserHost)) return false;
+				if (note.userId !== note.replyUserId && this.utilityService.isBlockedHost(this.meta.blockedHosts, note.replyUserHost)) return false;
+
+				if (note.user!.isSuspended) return false;
+				if (note.userId !== note.renoteUserId && note.renote?.user?.isSuspended) return false;
+				if (note.userId !== note.replyUserId && note.reply?.user?.isSuspended) return false;
+
+				if (nextUserFilters && isUserRelated(note, nextUserFilters.userIdsWhoBlockingMe)) return false;
+				if (nextUserFilters && isUserRelated(note, nextUserFilters.userIdsWhoMeMuting)) return false;
+				if (nextUserFilters && isUserRelated(note.renote, nextUserFilters.userIdsWhoBlockingMe)) return false;
+				if (nextUserFilters && isUserRelated(note.renote, nextUserFilters.userIdsWhoMeMuting)) return false;
+				if (nextUserFilters && isInstanceMuted(note, nextUserFilters.userMutedInstances)) return false;
+
+				return true;
+			}).sort((a, b) => a.id > b.id ? -1 : 1);
+
+			if (notes.length === 0) {
+				const nextOffset = offset + res.hits.length;
+				if (res.hits.length < limit || nextOffset >= res.estimatedTotalHits) {
+					return [];
+				}
+				return searchNext(nextOffset, remainingRetries - 1, nextUserFilters);
+			}
+
+			const packedNotes = (await this.noteEntityService.packMany(notes, me, { withReactionAndUserPairCache: true })).filter(note => !isMustRemove(note, 'home'));
+			const userIdsWhoMeMuting = nextUserFilters?.userIdsWhoMeMuting ?? new Set<string>();
+			await Promise.all(
+				packedNotes.map(note => removeMutedUsersReactions(note, userIdsWhoMeMuting)),
+			);
+
+			if (packedNotes.length > 0) {
+				return packedNotes;
+			}
+
+			const nextOffset = offset + res.hits.length;
+			if (res.hits.length < limit || nextOffset >= res.estimatedTotalHits) {
+				return [];
+			}
+
+			return searchNext(nextOffset, remainingRetries - 1, nextUserFilters);
+		};
+
+		return searchNext(0, SEARCH_EMPTY_PAGE_RETRY_LIMIT, null);
+	}
+
+	@bindThis
+	private async fetchSearchUserFilters(me: MiUser): Promise<SearchUserFilters> {
+		const [
+			userIdsWhoMeMuting,
+			userIdsWhoBlockingMe,
+			userMutedInstances,
+		] = await Promise.all([
+			this.cacheService.userMutingsCache.fetch(me.id),
+			this.cacheService.userBlockedCache.fetch(me.id),
+			this.cacheService.userProfileCache.fetch(me.id).then(p => new Set(p.mutedInstances)),
+		]);
+
+		return {
+			userIdsWhoMeMuting,
+			userIdsWhoBlockingMe,
+			userMutedInstances,
+		};
 	}
 }

--- a/packages/backend/test/e2e/hanamisearch.ts
+++ b/packages/backend/test/e2e/hanamisearch.ts
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+process.env.NODE_ENV = 'test';
+
+import * as assert from 'assert';
+import type * as misskey from 'misskey-js';
+import { api, signup } from '../utils.js';
+
+describe('HanamiSearch', () => {
+	let root: misskey.entities.SignupResponse;
+	let alice: misskey.entities.SignupResponse;
+
+	const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+	beforeAll(async () => {
+		root = await signup({ username: 'root' });
+		alice = await signup({ username: 'alice' });
+	}, 1000 * 60 * 2);
+
+	test('検索結果に凍結されたユーザーの投稿が含まれない', async () => {
+		const user = await signup({ username: 'search_suspended_user' });
+		const suspendedText = 'search_suspended_note';
+		const visibleText = `${suspendedText} visible`;
+
+		await api('notes/create', { text: suspendedText }, user);
+		await api('notes/create', { text: visibleText }, alice);
+		await api('admin/suspend-user', { userId: user.id }, root);
+		// indexに反映されるまで待つ(indexが終わったことを確認できないので時間を目分量で決める)
+		await wait(10000);
+
+		const res = await api('notes/hanamisearch-v1', {
+			query: suspendedText,
+		}, alice);
+
+		assert.strictEqual(res.status, 200);
+		assert.strictEqual(Array.isArray(res.body), true);
+		assert.strictEqual(res.body.some(note => note.userId === user.id), false);
+		assert.strictEqual(res.body.some(note => note.text === visibleText), true);
+	});
+
+	test('検索結果の先頭候補がフィルタで除外されても次の候補を返す', async () => {
+		const viewer = await signup({ username: 'search_filter_viewer' });
+		const mutee = await signup({ username: 'search_filter_mutee' });
+		const query = 'search_filtered_empty_page';
+		const visibleText = `${query} visible`;
+		const mutedText = `${query} muted`;
+
+		await api('notes/create', { text: visibleText }, alice);
+		await api('notes/create', { text: mutedText }, mutee);
+		await api('mute/create', { userId: mutee.id }, viewer);
+		// indexに反映されるまで待つ(indexが終わったことを確認できないので時間を目分量で決める)
+		await wait(10000);
+
+		const res = await api('notes/hanamisearch-v1', {
+			query,
+			limit: 1,
+		}, viewer);
+
+		assert.strictEqual(res.status, 200);
+		assert.strictEqual(Array.isArray(res.body), true);
+		assert.strictEqual(res.body.length, 1);
+		assert.strictEqual(res.body[0].text, visibleText);
+	});
+});


### PR DESCRIPTION
## Summary
- ノート検索の検索エンジン候補が後段フィルタで 0 件になった場合だけ、次の候補バッチを追加取得するようにしました。
- Meilisearch / Hanamisearch の検索結果に対して、凍結ユーザー、ブロックホスト、ミュート、ブロック、ミュートインスタンスを FanoutTimelineEndpointService に近い形でフィルタします。
- 凍結ユーザー投稿の除外と、フィルタ後空ページ回避の e2e を追加しました。

## Validation
- `PATH=/Users/kanaru/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm --filter backend exec tsc --noEmit`
- `PATH=/Users/kanaru/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm --filter backend exec eslint --quiet src/core/SearchService.ts src/core/hanamisearch/HanamiSearchService.ts test/e2e/note.ts`
