### PR TITLE
fix(hanamisearch): 索引へカスタム絵文字を送る

### DIFF
--- a/packages/backend/src/core/hanamisearch/HanamiSearchService.ts
+++ b/packages/backend/src/core/hanamisearch/HanamiSearchService.ts
@@ -71,6 +71,47 @@ function compileQuery(q: Q): string {
 	}
 }
 
+/**
+ * 索引へ送る 1 件ぶんを組み立てる。
+ *
+ * **クラスの外に出しているのは、ここが試験できる形でないと抜けに気づけないため。**
+ * 送る項目が足りないことは、送った側からは何も起きない。索引が受け取った分だけで
+ * 文書を作り、200 を返す。**気づくのは、PG から作り直した文書と突き合わせたとき**で、
+ * それは何日も後になる。
+ *
+ * 空の配列を `null` に畳むのは、索引側が「空の列」と「その項目が無い」を同じに
+ * 扱うため。畳まずに送ると、同じ投稿でも経路によって `_source` が変わり、
+ * **全件が「中身が違う」になる。**
+ */
+export function buildHanamiSearchDocument(note: MiNote, createdAt: number) {
+	return {
+		id: note.id,
+		createdAt,
+		userId: note.userId,
+		userHost: note.userHost,
+		channelId: note.channelId,
+		cw: note.cw,
+		text: note.text,
+		// 配列が空の場合は null にする（検索時のパフォーマンスのためにインデックスしない）
+		tags: (note.tags.length > 0) ? note.tags : null,
+		fileIds: (note.fileIds.length > 0) ? note.fileIds : null,
+		// **カスタム絵文字の「印」は、この列からしか導けない。**
+		//
+		// HanamiSearch はカスタム絵文字を `:name:` という印として索引に入れ、
+		// ファンマーク検索がそれを引く。本文からは導けない — 本文に書かれた
+		// `:name:` が実在する絵文字とは限らないので、索引側は本文を信じない。
+		//
+		// **送っていなかった。** そのため live で入った投稿だけ印を持たず、
+		// PG から作り直した分には付くので、突き合わせが毎周これを
+		// contentMismatch として出し、**昇格が止まっていた**。
+		//
+		// 2026-08-12 実測: 直近 20 分の索引対象 2,035 件のうち 451 件が食い違い、
+		// 欠けていた印 652 個は**全部カスタム絵文字**、Unicode 絵文字は 0 個。
+		// 10 日前から 3,000 件（作り直しで入った分）の食い違いは 0 件。
+		emojis: (note.emojis.length > 0) ? note.emojis : null,
+	};
+}
+
 @Injectable()
 export class HanamiSearchService {
 	private readonly hanamisearchIndexScope: 'local' | 'global' | string[] = 'global';
@@ -132,22 +173,7 @@ export class HanamiSearchService {
 		if (note.text == null && note.cw == null) return;
 		if (!['home', 'public'].includes(note.visibility)) return;
 
-		// 配列が空の場合は null にする（検索時のパフォーマンスのためにインデックスしない）
-		const fileIds = (note.fileIds.length > 0) ? note.fileIds : null;
-		const tags = (note.tags.length > 0) ? note.tags : null;
-
-		const createdAt = this.idService.parse(note.id).date.getTime();
-		const noteData = {
-			id: note.id,
-			createdAt,
-			userId: note.userId,
-			userHost: note.userHost,
-			channelId: note.channelId,
-			cw: note.cw,
-			text: note.text,
-			tags: tags,
-			fileIds: fileIds,
-		};
+		const noteData = buildHanamiSearchDocument(note, this.idService.parse(note.id).date.getTime());
 
 		const shouldIndex = (scope: string | string[], userHost: string | null): boolean => {
 			if (scope === 'global') return true;

--- a/packages/backend/test/unit/HanamiSearchService.ts
+++ b/packages/backend/test/unit/HanamiSearchService.ts
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test } from '@jest/globals';
+import { buildHanamiSearchDocument } from '@/core/hanamisearch/HanamiSearchService.js';
+import { MiNote } from '@/models/Note.js';
+
+function note(over: Partial<MiNote> = {}): MiNote {
+	return {
+		id: 'a1b2c3',
+		userId: 'u1',
+		userHost: null,
+		channelId: null,
+		cw: null,
+		text: '本文',
+		tags: [],
+		fileIds: [],
+		emojis: [],
+		visibility: 'public',
+		...over,
+	} as MiNote;
+}
+
+describe('buildHanamiSearchDocument', () => {
+	// **この試験が守っているのは「送り忘れ」そのもの。**
+	//
+	// `emojis` を送っていなかったので、live で入った投稿だけカスタム絵文字の
+	// 印を持たず、PG から作り直した分と食い違い続けた。突き合わせは毎周それを
+	// contentMismatch として出し、昇格が止まった (2026-08-12)。
+	//
+	// 送っていないことは、送った側からは何も起きない。索引は受け取った分で
+	// 文書を作って 200 を返す。**だからここで数える。**
+	test('カスタム絵文字を送る（送らないと索引が印を導けない）', () => {
+		const document = buildHanamiSearchDocument(note({ emojis: ['apple', 'peach'] }), 1);
+
+		expect(document.emojis).toEqual(['apple', 'peach']);
+	});
+
+	// 空の列を `null` に畳むのは索引側の取り決め。畳まずに送ると、同じ投稿でも
+	// 経路によって `_source` が変わり、**全件が「中身が違う」になる。**
+	test.each([
+		['emojis', { emojis: [] as string[] }],
+		['tags', { tags: [] as string[] }],
+		['fileIds', { fileIds: [] as string[] }],
+	])('%s は空なら null に畳む', (field, over) => {
+		const document = buildHanamiSearchDocument(note(over), 1);
+
+		expect(document[field as 'emojis' | 'tags' | 'fileIds']).toBeNull();
+	});
+
+	// 索引側の写像が読む項目を 1 つでも落とすと、その項目ぶんだけ静かにずれる。
+	// 名前を並べて数えるのは、**足りないことに気づく場所をここ 1 か所にする**ため。
+	test('索引が読む項目を全部送る', () => {
+		const document = buildHanamiSearchDocument(note(), 1);
+
+		expect(Object.keys(document).sort()).toEqual([
+			'channelId', 'createdAt', 'cw', 'emojis', 'fileIds', 'id', 'tags', 'text', 'userHost', 'userId',
+		]);
+	});
+});

--- a/packages/backend/test/unit/HanamiSearchService.ts
+++ b/packages/backend/test/unit/HanamiSearchService.ts
@@ -1,8 +1,3 @@
-/*
- * SPDX-FileCopyrightText: syuilo and misskey-project
- * SPDX-License-Identifier: AGPL-3.0-only
- */
-
 import { describe, expect, test } from '@jest/globals';
 import { buildHanamiSearchDocument } from '@/core/hanamisearch/HanamiSearchService.js';
 import { MiNote } from '@/models/Note.js';


### PR DESCRIPTION
## 何が起きていたか

live で入った投稿だけカスタム絵文字の「印」を持っていなかった。索引側は `emojis` 列から `:name:` という印を導いてファンマーク検索に使うが、**本文からは導けない**（本文に書かれた `:name:` が実在する絵文字とは限らないので、索引側は本文を信じない）。**送っていなかったので、導きようが無かった。**

PG から作り直した文書には付くため、突き合わせは毎周これを contentMismatch として出し続け、**新しい索引の昇格が止まっていた。**

## 実測 (2026-08-12、本番)

| 対象 | 索引対象 | 食い違い |
|---|---:|---:|
| 直近 20 分（live で入った分） | 2,035 | **451 (22%)** |
| 10 日前から 3,000 件（作り直しで入った分） | 1,720 | **0** |

- 欠けていた印 **652 個は全部カスタム絵文字**、Unicode 絵文字は 0 個
- 食い違った **451 件すべて**で PG の `emojis` 列は空でない
- **15 分待っても 173 件中 172 件が残った**ので、書き込み順の競合ではない

## 組み立てを関数に出した

**送り忘れは、送った側からは何も起きない。** 索引は受け取った分で文書を作って 200 を返す。気づくのは PG と突き合わせたときで、それは何日も後になる。

`buildHanamiSearchDocument` として出して、**足りないことに気づく場所を 1 か所**にした。試験は 3 つ:

- カスタム絵文字を送る
- 空の列は `null` に畳む（畳まないと経路によって `_source` が変わり、全件が「中身が違う」になる）
- **索引が読む項目を全部送る** — 次に項目が増えたときの抜けを止める

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pwpey1h5DDiGsw2jr8X2T