### PR TITLE
fix(backend): ファイルアップロード完了前の一時ファイル削除を修正

### DIFF
--- a/packages/backend/src/server/api/ApiCallService.ts
+++ b/packages/backend/src/server/api/ApiCallService.ts
@@ -225,8 +225,9 @@ export class ApiCallService implements OnApplicationShutdown {
 				reply.code(400);
 				return;
 			}
-			this.authenticateService.authenticate(token).then(([user, app]) => {
-				this.call(endpoint, user, app, fields, {
+			// Keep the temporary file until authentication and endpoint execution finish.
+			await this.authenticateService.authenticate(token).then(async ([user, app]) => {
+				await this.call(endpoint, user, app, fields, {
 					name: multipartData.filename,
 					path: path,
 				}, request).then((res) => {


### PR DESCRIPTION
ファイルアップロード処理で、一時ファイルが処理完了前に削除される回帰を修正します。`handleMultipartRequest` で非同期処理の完了を待ち、後処理を実行する順序を修正します。

更新前の `e645c18382` と次の `6b4d802c99` では再現せず、`423e3e7759` で再現することを比較検証しました。2026-09-07の稼働ログでも同じ症状を確認しています。

検証:

- 修正前の失敗と、修正後のファイル読取り成功を確認。
- 正常終了・認証失敗・処理失敗後に一時ファイルが削除されることを確認。

認証と保存処理を模擬し、実ファイルを使った検証です。サーバー全体のビルド、DB・オブジェクトストレージへの保存、本番適用後のアップロードは未検証です。
